### PR TITLE
make `AddSubQuery` fn part of the Query interface

### DIFF
--- a/and.go
+++ b/and.go
@@ -30,7 +30,7 @@ func And(queries ...Query) *AndQuery {
 	return a
 }
 
-func (q *AndQuery) AddSubQuery(sub Query) *AndQuery {
+func (q *AndQuery) AddSubQuery(sub Query) Query {
 	q.queries = append(q.queries, sub)
 	q.sortSubqueries()
 	return q

--- a/constant.go
+++ b/constant.go
@@ -46,3 +46,7 @@ func (q *ConstantQuery) SetBoost(b float32) Query {
 func (q *ConstantQuery) PayloadDecode(p Payload) {
 	panic("unsupported")
 }
+
+func (q *ConstantQuery) AddSubQuery(Query) Query {
+	panic("unsupported")
+}

--- a/dismax.go
+++ b/dismax.go
@@ -28,7 +28,7 @@ func DisMax(tieBreaker float32, queries ...Query) *DisMaxQuery {
 	}
 }
 
-func (q *DisMaxQuery) AddSubQuery(sub Query) *DisMaxQuery {
+func (q *DisMaxQuery) AddSubQuery(sub Query) Query {
 	q.queries = append(q.queries, sub)
 	q.scores = make([]float32, len(q.queries))
 	return q

--- a/file_term.go
+++ b/file_term.go
@@ -144,6 +144,10 @@ func (t *FileTermData) PayloadDecode(p Payload) {
 	panic("unsupported")
 }
 
+func (t *FileTermData) AddSubQuery(Query) Query {
+	panic("unsupported")
+}
+
 func AppendFileNameTerm(fn string, docs []int32) error {
 	f, err := os.OpenFile(fn, os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {

--- a/or.go
+++ b/or.go
@@ -17,7 +17,7 @@ func Or(queries ...Query) *OrQuery {
 	}
 }
 
-func (q *OrQuery) AddSubQuery(sub Query) *OrQuery {
+func (q *OrQuery) AddSubQuery(sub Query) Query {
 	q.queries = append(q.queries, sub)
 	return q
 }

--- a/payload_term.go
+++ b/payload_term.go
@@ -52,3 +52,7 @@ func (t *PayloadTermQuery) PayloadDecode(p Payload) {
 
 	p.Consume(t.term.docId, t.term.cursor, t.payload)
 }
+
+func (t *PayloadTermQuery) AddSubQuery(Query) Query {
+	panic("unsupported")
+}

--- a/query.go
+++ b/query.go
@@ -31,6 +31,7 @@ type Query interface {
 	SetBoost(float32) Query
 	Cost() int
 	String() string
+	AddSubQuery(Query) Query
 
 	PayloadDecode(p Payload)
 }

--- a/term.go
+++ b/term.go
@@ -165,3 +165,7 @@ func (t *TermQuery) SetBoost(b float32) Query {
 func (t *TermQuery) PayloadDecode(p Payload) {
 	panic("unsupported")
 }
+
+func (t *TermQuery) AddSubQuery(Query) Query {
+	panic("unsupported")
+}


### PR DESCRIPTION
This would allow increased interchangeability between different types
of queries.

But this would be a breaking change :/